### PR TITLE
Fix search highlight when the highlight immediately followed another highlight

### DIFF
--- a/src/components/filtersMenu/searchInput/getTextWithHighlight.tsx
+++ b/src/components/filtersMenu/searchInput/getTextWithHighlight.tsx
@@ -1,26 +1,16 @@
 import { HIGHLIGHT_INDICATOR } from './constants';
 
-const getTextWithHighlight = (text: string) => {
-  const startsWithHighlight = text.startsWith(HIGHLIGHT_INDICATOR);
-
-  return text
+const getTextWithHighlight = (text: string) =>
+  text
     .split(HIGHLIGHT_INDICATOR)
-    .filter((value) => value)
     .map((phrasePart, index) => {
-      if (startsWithHighlight) {
-        if (index % 2 === 0) {
-          return <mark>{phrasePart}</mark>;
-        }
-
-        return phrasePart;
-      }
-
+      if (phrasePart === '') return null;
       if (index % 2 === 0) {
         return phrasePart;
+      } else {
+        return <mark>{phrasePart}</mark>;
       }
-
-      return <mark>{phrasePart}</mark>;
-    });
-};
+    })
+    .filter(Boolean);
 
 export default getTextWithHighlight;

--- a/src/components/filtersMenu/searchInput/specs/getTextWithHighlight.spec.tsx
+++ b/src/components/filtersMenu/searchInput/specs/getTextWithHighlight.spec.tsx
@@ -25,6 +25,10 @@ const cases: [string, Array<string | React.JSX.Element>][] = [
     "L**or,em Ip.sum D?olor S'it Am!e**t",
     ['L', <mark>or,em Ip.sum D?olor S'it Am!e</mark>, 't'],
   ],
+  [
+    '**Lor****em** ipsum dolor sit **amet**',
+    [<mark>Lor</mark>, <mark>em</mark>, ' ipsum dolor sit ', <mark>amet</mark>],
+  ],
 ];
 
 describe('getTextWithHighlight', () => {


### PR DESCRIPTION
For example, it wasn't working correctly in the word "assassin" when search phrase was "ass"